### PR TITLE
ロゴ余白・メニューのデザイン調整

### DIFF
--- a/WebContent/css/topframe.css
+++ b/WebContent/css/topframe.css
@@ -80,7 +80,7 @@ address{
 
 	.menu{
 		margin:45px 0 0 0;
-		padding:30px 0px 20px 0px;
+		padding:30px 0px 20px 20px;
 
 		position: absolute;
 		position: -webkit-sticky; /* Safari対応 */

--- a/WebContent/css/topframe.css
+++ b/WebContent/css/topframe.css
@@ -91,7 +91,7 @@ address{
 
 		text-align:center;
 		font-family: "Times New Roman";
-		font-size:1.5vw;
+		font-size:calc(7px + 0.75*1.5vw);
 
 		width:100%;
 		box-sizing:border-box;
@@ -103,8 +103,8 @@ address{
 
 	.menu li {
 		/*	width:100px;*/
-		padding:10px 1.5vw 0px 1.5vw;
-		margin:0 1vw 0 1vw;
+		padding:10px calc(1vw * 2 + 2px) 0px calc(vw * 2 + 2px);
+		margin:0 0.5vw 0 0.5vw;
 		display:inline-block;
 	}
 

--- a/WebContent/css/topframe.css
+++ b/WebContent/css/topframe.css
@@ -28,7 +28,7 @@ address{
 /* レスポンシブ対応 PC向け */
 @media only screen and (min-width:666px){
 	#toplogo {
-		margin:25px 40px 5px 40px;
+		margin:25px 40px 5px 4vw;
 		position: fixed !important;
 		position: absolute;
 		top:0;
@@ -86,14 +86,14 @@ address{
 		position: -webkit-sticky; /* Safari対応 */
 		position: sticky;
 		top:0px;
-		left:0px;
-		right:0px;
+		left:15%;
+		right:15%;
 
 		text-align:center;
 		font-family: "Times New Roman";
-		font-size:calc(7px + 0.75*1.5vw);
+		font-size:calc(5px + calc(0.75*1.5vw));
 
-		width:100%;
+		width:70%;
 		box-sizing:border-box;
 
 		background-color: #ffffff;
@@ -103,8 +103,8 @@ address{
 
 	.menu li {
 		/*	width:100px;*/
-		padding:10px calc(1vw * 2 + 2px) 0px calc(vw * 2 + 2px);
-		margin:0 0.5vw 0 0.5vw;
+		padding:10px 1.5vw 0px 1.5vw;
+		margin:0 0 0 0;
 		display:inline-block;
 	}
 


### PR DESCRIPTION
１パソコン画面において、toplogoの左のマージンを可変にした
　（→画面サイズを小さくしてもメニューと近くならないように）

２メニューの各項目の間隔を調整。またフォントサイズを調整。