### PR TITLE
携帯画面のロゴのバグを解消

### DIFF
--- a/WebContent/css/topframe.css
+++ b/WebContent/css/topframe.css
@@ -223,15 +223,15 @@ address{
 		margin:0vw 3vw 2vw 3vw;
 		position: fixed!important;
 		position: absolute;
-		top:3.5vh;
+		top:1.3vh;
 		left:0.1vw;
 		text-align:left;
 
-		height:7vh;
+		height:4.2vh;
 		width:100px;
 		z-index:10;
 
-		transform:translateY(-3.5vh);
+
 
 		background-image:url(../images/logo1.png);
 		background-position:center center;


### PR DESCRIPTION
携帯画面で、ロゴの調整によって発生したバグ（メニューを開いた際に、ロゴが左に動く動作が適応されない）
を解消